### PR TITLE
chore: Bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cclabsnz/sf-flow-apex-converter",
-  "version": "1.0.42",
+  "version": "1.1.0",
   "description": "CLI tool to convert Salesforce Flows into bulkified Apex classes",
   "main": "dist/index.js",
   "scripts": {
@@ -60,7 +60,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=14.20.0"
+    "node": "18.20.8",
+    "npm": "10.8.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the package version to 1.1.0 to reflect the recent changes and allow for a new release.