### PR TITLE
Handle fault connectors during flow analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,14 +51,9 @@ coverage/
 flow-analysis-report.json
 flow-analysis-details.json
 sf-flow-apex-converter-details.json
-<<<<<<< HEAD
-
-# Tool-specific directories
-=======
 sf-flow-apex-converter.log
 generated-apex/
 test-output/
 
 # Serena/Claude
->>>>>>> feature/simplified-bulkification
 .serena/

--- a/src/utils/SimplifiedFlowAnalyzer.ts
+++ b/src/utils/SimplifiedFlowAnalyzer.ts
@@ -333,7 +333,26 @@ export class SimplifiedFlowAnalyzer {
     if (element.defaultconnector?.targetreference) {
       nextElements.push(element.defaultconnector.targetreference);
     }
-    
+
+    // Fault connector
+    if (element.faultconnector?.targetreference) {
+      nextElements.push(element.faultconnector.targetreference);
+    }
+
+    // Multiple fault connectors (some elements support arrays)
+    if (element.faultconnectors) {
+      const faults = Array.isArray(element.faultconnectors)
+        ? element.faultconnectors
+        : [element.faultconnectors];
+      for (const fault of faults) {
+        if (fault.targetreference) {
+          nextElements.push(fault.targetreference);
+        } else if (fault.connector?.targetreference) {
+          nextElements.push(fault.connector.targetreference);
+        }
+      }
+    }
+
     // Decision rules
     if (element.rules) {
       const rules = Array.isArray(element.rules) ? element.rules : [element.rules];

--- a/tests/SimplifiedFlowAnalyzer.test.ts
+++ b/tests/SimplifiedFlowAnalyzer.test.ts
@@ -1,0 +1,37 @@
+import { SimplifiedFlowAnalyzer } from '../src/utils/SimplifiedFlowAnalyzer.js';
+
+describe('SimplifiedFlowAnalyzer', () => {
+  test('includes fault connector targets in execution path', async () => {
+    const analyzer = new SimplifiedFlowAnalyzer();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<flow>
+  <actioncalls>
+    <name>Do_Something</name>
+    <actionname>SomeAction</actionname>
+    <connector>
+      <targetreference>Done</targetreference>
+    </connector>
+    <faultconnector>
+      <targetreference>Handle_Error</targetreference>
+    </faultconnector>
+  </actioncalls>
+  <assignments>
+    <name>Handle_Error</name>
+    <connector>
+      <targetreference>Done</targetreference>
+    </connector>
+  </assignments>
+  <assignments>
+    <name>Done</name>
+  </assignments>
+  <start>
+    <connector>
+      <targetreference>Do_Something</targetreference>
+    </connector>
+  </start>
+</flow>`;
+
+    const result = await analyzer.analyzeFlow(xml, 'TestFlow');
+    expect(result.executionPath).toContain('Handle_Error');
+  });
+});


### PR DESCRIPTION
## Summary
- include fault connector paths when discovering next elements so error branches are analyzed
- add regression test for fault connector traversal
- clean up `.gitignore` merge conflict markers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68994f4b1fec83299ef59ca29a9dce9a